### PR TITLE
Add devtools managed files to RuboCop exclude

### DIFF
--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -2,6 +2,11 @@
 
 AllCops:
   TargetRubyVersion: 2.4
+  Exclude:
+    - spec/support/coverage.rb
+    - spec/support/warnings.rb
+    - Gemfile.devtools
+    - "*.gemspec"
 
 Style/StringLiterals:
   Enabled: true


### PR DESCRIPTION
This makes it easier to run `rubocop -x` or `rubocop -a` in devtools-managed projects.