### PR TITLE
Adjust rubocop rules

### DIFF
--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -35,7 +35,7 @@ Naming/PredicateName:
 
 Naming/FileName:
   Exclude:
-    - "lib/dry-*.rb"
+    - "lib/*-*.rb"
 
 Naming/MethodName:
   Enabled: false

--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -18,6 +18,11 @@ Layout/MultilineMethodCallIndentation:
 Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+
 Lint/HandleExceptions:
   Exclude:
     - "spec/spec_helper.rb"
@@ -76,6 +81,15 @@ Style/ClassAndModuleChildren:
 
 Style/ConditionalAssignment:
   Enabled: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+  ConsistentQuotesInMultiline: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
 
 Style/DateTime:
   Enabled: false

--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -45,6 +45,8 @@ Naming/MemoizedInstanceVariableName:
 
 Metrics/LineLength:
   Max: 100
+  Exclude:
+    - "spec/**/*_spec.rb"
 
 Metrics/MethodLength:
   Enabled: false


### PR DESCRIPTION
1. Update some style rules to match modern conventions:

    - Require no spaces inside hash literals
    - Require double quotes around string literals
    
    Both of these match the behavior of the standardrb project
2. Exclude spec files from line length limitation: it's common that some of these files may have long descriptions in their `it` blocks, so having to worry about line length here is bothersome
3. Accept any files named foo-bar.rb directly inside `lib/`: this removes the only mention of "dry" from these Rubocop rules, which makes them more widely applicable (my use case was running them over the dry-view project that I'm currently renaming to hanami-view)