### PR TITLE
Disable Lint/ConstantDefinitionInBlock in specs

### DIFF
--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -35,6 +35,10 @@ Layout/LineLength:
 Lint/BooleanSymbol:
   Enabled: false
 
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - "spec/**/*_spec.rb"
+
 Lint/RaiseException:
   Enabled: false
 


### PR DESCRIPTION
In some of our projects, it makes sense to define new classes within `before` blocks in specs. Disabling this rule for the specs will stop Codacy from complaining about it.

See the definition of `Test::Container` inside `spec/integration/container/auto_registration/mixed_namespaces_spec.rb` in https://github.com/dry-rb/dry-system/pull/158/files as an example.