### PR TITLE
Gemfile.devtools: Remove Bundler < 2 workaround

### DIFF
--- a/shared/Gemfile.devtools
+++ b/shared/Gemfile.devtools
@@ -2,8 +2,6 @@
 
 # this file is managed by dry-rb/devtools project
 
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-
 group :test do
   gem "simplecov", require: false, platforms: :ruby
   gem "simplecov-cobertura", require: false, platforms: :ruby


### PR DESCRIPTION
If Bundler 2.x is used everywhere, we do not need the workaround anymore.

I found this while browsing dry-files repo.