### PR TITLE
Fix sorting of project versions

### DIFF
--- a/bin/add-docsite
+++ b/bin/add-docsite
@@ -24,7 +24,7 @@ Dir.chdir(website_path) do
     else
       project_versions = project_entry["versions"]
       project_versions << version_entry
-      project_versions.sort! { |entry| entry["value"].to_f }
+      project_versions.sort_by! { |entry| entry["value"].split(".").map(&:to_i) }.reverse!
 
       File.write(projects_yaml, YAML.dump(project_data))
 


### PR DESCRIPTION
This is a fix for https://github.com/dry-rb/dry-rb.org/issues/400, together with https://github.com/dry-rb/dry-rb.org/pull/401.

It currently sorts version numbers in descending order, with `main` last. If we expect to have other non-numeric versions, we should also return the original string to keep those sorted.